### PR TITLE
no unsetting of roi

### DIFF
--- a/src/metavision_wrapper.cpp
+++ b/src/metavision_wrapper.cpp
@@ -144,7 +144,8 @@ void MetavisionWrapper::applyROI(const std::vector<int> & roi)
       cam_.roi().set(rects);
     }
   } else {
-    cam_.roi().unset();
+    // unsetting the ROI upsets the Gen4 sensor
+    // cam_.roi().unset();
 #ifdef CHECK_IF_OUTSIDE_ROI
     x_min_ = 0;
     x_max_ = std::numeric_limits<uint16_t>::max();


### PR DESCRIPTION
don't unset the ROI if none is specified (the Gen4 does not seem to like it)