### PR TITLE
added dumping of additional statistics, cleaner exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Services:
   this to work the ``bias_file`` parameter must be set to a non-empty value.
 - ``save_settings``: write out current camera settings to settings file. For
   this to work the ``settings`` parameter must be set to a non-empty value.
+- ``dump_statistics``: print extra statistics like the average size of SDK packets.
 
 Dynamic reconfiguration parameters
 (see [MetaVision documentation here](https://docs.prophesee.ai/stable/hw/manuals/biases.html)):

--- a/include/metavision_driver/driver_ros2.h
+++ b/include/metavision_driver/driver_ros2.h
@@ -16,6 +16,7 @@
 #ifndef METAVISION_DRIVER__DRIVER_ROS2_H_
 #define METAVISION_DRIVER__DRIVER_ROS2_H_
 
+#include <chrono>
 #include <event_camera_msgs/msg/event_packet.hpp>
 #include <map>
 #include <memory>
@@ -55,6 +56,9 @@ private:
   void saveSettings(
     const std::shared_ptr<Trigger::Request> request,
     const std::shared_ptr<Trigger::Response> response);
+  void dumpStatistics(
+    const std::shared_ptr<Trigger::Request> request,
+    const std::shared_ptr<Trigger::Response> response);
 
   // related to dynanmic config (runtime parameter update)
   rcl_interfaces::msg::SetParametersResult parameterChanged(
@@ -82,6 +86,9 @@ private:
   uint64_t lastMessageTime_{0};
   uint64_t messageThresholdTime_{0};  // threshold time for sending message
   size_t messageThresholdSize_{0};    // threshold size for sending message
+  size_t numInputPackets_{0};
+  size_t numInputBytes_{0};
+  std::chrono::steady_clock::time_point startStatisticsTime_;
   EventPacketMsg::UniquePtr msg_;
   rclcpp::Publisher<EventPacketMsg>::SharedPtr eventPub_;
   // ------ related to sync
@@ -95,6 +102,7 @@ private:
   ParameterMap biasParameters_;
   rclcpp::Service<Trigger>::SharedPtr saveBiasesService_;
   rclcpp::Service<Trigger>::SharedPtr saveSettingsService_;
+  rclcpp::Service<Trigger>::SharedPtr dumpStatisticsService_;
 };
 }  // namespace metavision_driver
 #endif  // METAVISION_DRIVER__DRIVER_ROS2_H_

--- a/include/metavision_driver/metavision_wrapper.h
+++ b/include/metavision_driver/metavision_wrapper.h
@@ -204,6 +204,7 @@ private:
   std::chrono::time_point<std::chrono::system_clock> lastPrintTime_;
   Stats stats_;
   std::mutex statsMutex_;
+  std::condition_variable statsCV_;
   std::shared_ptr<std::thread> statsThread_;
 
   // -----------

--- a/launch/driver_composition.launch.py
+++ b/launch/driver_composition.launch.py
@@ -26,15 +26,6 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
 
-fixed_params = {
-    "use_multithreading": False,
-    "bias_file": "",
-    "camerainfo_url": "",
-    "frame_id": "",
-    "event_message_time_threshold": 1.0e-3,
-}
-
-
 def make_renderer(camera):
     return ComposableNode(
         package="event_camera_renderer",
@@ -75,6 +66,7 @@ def launch_setup(context, *args, **kwargs):
         {
             "serial": LaunchConfig("serial").perform(context),
             "settings": LaunchConfig("settings").perform(context),
+            "statistics_print_interval": float(LaunchConfig("statistics_print_interval").perform(context)),
         }
     ]
     remappings = []
@@ -129,6 +121,11 @@ def generate_launch_description():
                 "fps",
                 default_value=["fps"],
                 description="renderer and fibar frame rate in Hz",
+            ),
+            LaunchArg(
+                "statistics_print_interval",
+                default_value=["2.0"],
+                description="time in seconds between statistics printing",
             ),
             LaunchArg(
                 "with_renderer",

--- a/launch/driver_composition.launch.py
+++ b/launch/driver_composition.launch.py
@@ -66,7 +66,9 @@ def launch_setup(context, *args, **kwargs):
         {
             "serial": LaunchConfig("serial").perform(context),
             "settings": LaunchConfig("settings").perform(context),
-            "statistics_print_interval": float(LaunchConfig("statistics_print_interval").perform(context)),
+            "statistics_print_interval": float(
+                LaunchConfig("statistics_print_interval").perform(context)
+            ),
         }
     ]
     remappings = []

--- a/src/driver_ros2.cpp
+++ b/src/driver_ros2.cpp
@@ -110,6 +110,28 @@ void DriverROS2::saveSettings(
   response->message += (response->success ? "succeeded" : "failed");
 }
 
+void DriverROS2::dumpStatistics(
+  const std::shared_ptr<Trigger::Request>, const std::shared_ptr<Trigger::Response> response)
+{
+  response->success = false;
+  response->message = "dumping statistics succeeded";
+  const auto endTime = std::chrono::steady_clock::now();
+  const auto dt =
+    std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startStatisticsTime_)
+      .count();
+  const auto dt_inv = (dt > 0) ? (1.0 / dt) : 0.0;
+  const double inputBandwidth = numInputBytes_ * dt_inv;
+  const double inputMsgRate = numInputPackets_ * dt_inv;
+  const double avgMsgSize =
+    (numInputPackets_ > 0) ? (static_cast<double>(numInputBytes_) / numInputPackets_) : 0.0;
+  LOG_INFO_FMT(
+    "input bw: %.4f MB/s, msg rate: %.2f msgs/s, avg msg size: %.0f bytes",
+    inputBandwidth / (1024.0 * 1024.0), inputMsgRate, avgMsgSize);
+  numInputBytes_ = 0;
+  numInputPackets_ = 0;
+  startStatisticsTime_ = endTime;
+}
+
 rcl_interfaces::msg::SetParametersResult DriverROS2::parameterChanged(
   const std::vector<rclcpp::Parameter> & params)
 {
@@ -284,7 +306,7 @@ void DriverROS2::start()
 
   // ------ start camera, may get callbacks from then on
   wrapper_->startCamera(this);
-
+  startStatisticsTime_ = std::chrono::steady_clock::now();
   if (wrapper_->getFromFile().empty()) {
     declareBiasParameters(wrapper_->getSensorVersion());
     callbackHandle_ = this->add_on_set_parameters_callback(
@@ -299,6 +321,9 @@ void DriverROS2::start()
     saveSettingsService_ = this->create_service<Trigger>(
       "~/save_settings",
       std::bind(&DriverROS2::saveSettings, this, std::placeholders::_1, std::placeholders::_2));
+    dumpStatisticsService_ = this->create_service<Trigger>(
+      "~/dump_statistics",
+      std::bind(&DriverROS2::dumpStatistics, this, std::placeholders::_1, std::placeholders::_2));
   }
 }
 
@@ -438,6 +463,8 @@ void DriverROS2::rawDataCallback(uint64_t t, const uint8_t * start, const uint8_
       msg_.reset();
     }
   }
+  numInputPackets_++;
+  numInputBytes_ += (end - start);
 }
 
 void DriverROS2::eventCDCallback(

--- a/src/metavision_wrapper.cpp
+++ b/src/metavision_wrapper.cpp
@@ -186,7 +186,7 @@ bool MetavisionWrapper::stop()
   if (statsThread_) {
     {
       std::unique_lock<std::mutex> lock(mutex_);
-      cv_.notify_all();
+      statsCV_.notify_all();
     }
     statsThread_->join();
     statsThread_.reset();
@@ -703,26 +703,26 @@ void MetavisionWrapper::setExternalTriggerOutMode(
 
 void MetavisionWrapper::statsThread()
 {
+  std::unique_lock<std::mutex> lock(statsMutex_);
+  const auto wait_time = std::chrono::milliseconds(static_cast<int>(statsInterval_ * 1000));
   while (GENERIC_ROS_OK() && keepRunning_) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(statsInterval_ * 1000)));
-    printStatistics();
+    statsCV_.wait_for(lock, wait_time);
+    if (GENERIC_ROS_OK() && keepRunning_) {
+      printStatistics();
+    }
   }
   LOG_INFO_NAMED("statistics thread exited!");
 }
 
 void MetavisionWrapper::printStatistics()
 {
-  Stats stats;
-  {
-    std::unique_lock<std::mutex> lock(statsMutex_);
-    stats = stats_;
-    stats_ = Stats();  // reset statistics
-  }
+  Stats stats = stats_;  // shorthand
   std::chrono::time_point<std::chrono::system_clock> t_now = std::chrono::system_clock::now();
   const double dt = std::chrono::duration<double>(t_now - lastPrintTime_).count();
   lastPrintTime_ = t_now;
   const double invT = dt > 0 ? 1.0 / dt : 0;
-  const double recvByteRate = 1e-6 * stats.bytesRecv * invT;
+  constexpr double bytesToMB = 1.0 / (1024.0 * 1024.0);
+  const double recvByteRate = stats.bytesRecv * invT * bytesToMB;
 
   const int recvMsgRate = static_cast<int>(stats.msgsRecv * invT);
   const int sendMsgRate = static_cast<int>(stats.msgsSent * invT);
@@ -750,6 +750,7 @@ void MetavisionWrapper::printStatistics()
       recvMsgRate, sendMsgRate);
   }
 #endif
+  stats_ = Stats();  // reset statistics
 }
 
 }  // namespace metavision_driver


### PR DESCRIPTION
- added dump_statistics service call to print additional driver statistics
- cleaned up a launch file and added statistics_print_interval argument
- use timed conditional variable wait for cleaner exit of statistics thread in the metavision wrapper