### PR TITLE
fix crash when playing from file

### DIFF
--- a/src/metavision_wrapper.cpp
+++ b/src/metavision_wrapper.cpp
@@ -386,10 +386,12 @@ bool MetavisionWrapper::loadBiases()
 
 void MetavisionWrapper::printBiases()
 {
-  const auto biases = cam_.get_device().get_facility<Metavision::I_LL_Biases>();
-  const auto pmap = biases->get_all_biases();
-  for (const auto & bp : pmap) {
-    LOG_INFO_NAMED("using bias param: " << bp.first << " " << bp.second);
+  if (fromFile_.empty()) {
+    const auto biases = cam_.get_device().get_facility<Metavision::I_LL_Biases>();
+    const auto pmap = biases->get_all_biases();
+    for (const auto & bp : pmap) {
+      LOG_INFO_NAMED("using bias param: " << bp.first << " " << bp.second);
+    }
   }
 }
 


### PR DESCRIPTION
Playing back from file results in a crash due to a segfault because there are no biases but `printBiases` has no check for it.